### PR TITLE
bugFix in SALMON.py

### DIFF
--- a/model/SALMON.py
+++ b/model/SALMON.py
@@ -163,7 +163,7 @@ def CIndex(hazards, labels, survtime_all):
                 if survtime_all[j] > survtime_all[i]:
                     total = total + 1
                     if hazards[j] < hazards[i]: concord = concord + 1
-                    elif hazards[j] < hazards[i]: concord = concord + 0.5
+                    elif hazards[j] == hazards[i]: concord = concord + 0.5
 
     return(concord/total)
     


### PR DESCRIPTION
 CIndex() :
```
if hazards[j] < hazards[i]: concord = concord + 1
elif hazards[j] == hazards[i]: concord = concord + 0.5
```